### PR TITLE
FAI-2524 Connect outer api endpoint in recruit for application review dashboard numbers

### DIFF
--- a/src/Recruit.Api.Data/ApplicationReview/ApplicationReviewRepository.cs
+++ b/src/Recruit.Api.Data/ApplicationReview/ApplicationReviewRepository.cs
@@ -23,8 +23,8 @@ public interface IApplicationReviewRepository
         CancellationToken token = default);
     Task<UpsertResult<ApplicationReviewEntity>> Upsert(ApplicationReviewEntity entity, CancellationToken token = default);
     Task<ApplicationReviewEntity?> Update(ApplicationReviewEntity entity, CancellationToken token = default);
-    Task<List<ApplicationReviewEntity>> GetAllByAccountId(long accountId, string status, CancellationToken token = default);
-    Task<List<ApplicationReviewEntity>> GetAllByUkprn(int ukprn, string status, CancellationToken token = default);
+    Task<List<ApplicationReviewEntity>> GetAllByAccountId(long accountId, CancellationToken token = default);
+    Task<List<ApplicationReviewEntity>> GetAllByUkprn(int ukprn, CancellationToken token = default);
     Task<List<ApplicationReviewEntity>> GetAllByUkprn(int ukprn, List<long> vacancyReferences, CancellationToken token = default);
     Task<List<ApplicationReviewEntity>> GetAllByAccountId(long accountId, List<long> vacancyReferences, CancellationToken token = default);
 }
@@ -92,19 +92,19 @@ internal class ApplicationReviewRepository(IRecruitDataContext recruitDataContex
         return entity;
     }
 
-    public async Task<List<ApplicationReviewEntity>> GetAllByAccountId(long accountId, string status, CancellationToken token = default)
+    public async Task<List<ApplicationReviewEntity>> GetAllByAccountId(long accountId, CancellationToken token = default)
     {
         return await recruitDataContext.ApplicationReviewEntities
             .AsNoTracking()
-            .Where(fil => fil.AccountId == accountId && fil.Status == status)
+            .Where(fil => fil.AccountId == accountId)
             .ToListAsync(token);
     }
 
-    public async Task<List<ApplicationReviewEntity>> GetAllByUkprn(int ukprn, string status, CancellationToken token = default)
+    public async Task<List<ApplicationReviewEntity>> GetAllByUkprn(int ukprn, CancellationToken token = default)
     {
         return await recruitDataContext.ApplicationReviewEntities
             .AsNoTracking()
-            .Where(fil => fil.Ukprn == ukprn && fil.Status == status)
+            .Where(fil => fil.Ukprn == ukprn)
             .ToListAsync(token);
     }
 

--- a/src/Recruit.Api.UnitTests/Application/Providers/ApplicationReviewsProviderTests/WhenGettingDashboardCountByAccountId.cs
+++ b/src/Recruit.Api.UnitTests/Application/Providers/ApplicationReviewsProviderTests/WhenGettingDashboardCountByAccountId.cs
@@ -11,57 +11,52 @@ namespace SFA.DAS.Recruit.Api.UnitTests.Application.Providers.ApplicationReviews
         [Test, MoqAutoData]
         public async Task GettingDashboardByAccountId_Given_Status_Submitted_And_ReviewDate_Null_ShouldReturnDashboard(
             long accountId,
-            ApplicationReviewStatus status,
             CancellationToken token,
             List<ApplicationReviewEntity> entities,
             [Frozen] Mock<IApplicationReviewRepository> repositoryMock,
             [Greedy] ApplicationReviewsProvider provider)
         {
             // Arrange
-            status = ApplicationReviewStatus.New;
             foreach (var entity in entities)
             {
-                entity.Status = status.ToString();
-                entity.ReviewedDate = null;
+                entity.Status = ApplicationReviewStatus.New.ToString();
                 entity.WithdrawnDate = null;
             }
-            repositoryMock.Setup(repo => repo.GetAllByAccountId(accountId, status.ToString(), token))
+            repositoryMock.Setup(repo => repo.GetAllByAccountId(accountId, token))
                 .ReturnsAsync(entities);
             // Act
-            var result = await provider.GetCountByAccountId(accountId, status, token);
+            var result = await provider.GetCountByAccountId(accountId, token);
             
             // Assert
             result.NewApplicationsCount.Should().Be(entities.Count);
             result.EmployerReviewedApplicationsCount.Should().Be(0);
-            repositoryMock.Verify(repo => repo.GetAllByAccountId(accountId, status.ToString(), token), Times.Once);
+            repositoryMock.Verify(repo => repo.GetAllByAccountId(accountId, token), Times.Once);
         }
 
-        [Test, MoqAutoData]
+        [Test]
+        [MoqInlineAutoData(ApplicationReviewStatus.EmployerUnsuccessful)]
+        [MoqInlineAutoData(ApplicationReviewStatus.EmployerInterviewing)]
         public async Task GettingDashboardByAccountId_Given_Status_Submitted_And_ReviewDate__Not_Null_ShouldReturnDashboard(
-            long accountId,
             ApplicationReviewStatus status,
+            long accountId,
             CancellationToken token,
             List<ApplicationReviewEntity> entities,
             [Frozen] Mock<IApplicationReviewRepository> repositoryMock,
             [Greedy] ApplicationReviewsProvider provider)
         {
             // Arrange
-            status = ApplicationReviewStatus.Interviewing;
             foreach (var entity in entities)
             {
                 entity.Status = status.ToString();
-                entity.ReviewedDate = DateTime.Now;
-                entity.WithdrawnDate = null;
             }
-            repositoryMock.Setup(repo => repo.GetAllByAccountId(accountId, status.ToString(), token))
+            repositoryMock.Setup(repo => repo.GetAllByAccountId(accountId, token))
                 .ReturnsAsync(entities);
             // Act
-            var result = await provider.GetCountByAccountId(accountId, status, token);
+            var result = await provider.GetCountByAccountId(accountId, token);
 
             // Assert
-            result.NewApplicationsCount.Should().Be(0);
             result.EmployerReviewedApplicationsCount.Should().Be(entities.Count);
-            repositoryMock.Verify(repo => repo.GetAllByAccountId(accountId, status.ToString(), token), Times.Once);
+            repositoryMock.Verify(repo => repo.GetAllByAccountId(accountId, token), Times.Once);
         }
     }
 }

--- a/src/Recruit.Api.UnitTests/Application/Providers/ApplicationReviewsProviderTests/WhenGettingDashboardCountByUkprn.cs
+++ b/src/Recruit.Api.UnitTests/Application/Providers/ApplicationReviewsProviderTests/WhenGettingDashboardCountByUkprn.cs
@@ -25,43 +25,41 @@ namespace SFA.DAS.Recruit.Api.UnitTests.Application.Providers.ApplicationReviews
                 entity.ReviewedDate = null;
                 entity.WithdrawnDate = null;
             }
-            repositoryMock.Setup(repo => repo.GetAllByUkprn(ukprn, status.ToString(), token))
+            repositoryMock.Setup(repo => repo.GetAllByUkprn(ukprn, token))
                 .ReturnsAsync(entities);
             // Act
-            var result = await provider.GetCountByUkprn(ukprn, status, token);
+            var result = await provider.GetCountByUkprn(ukprn, token);
             
             // Assert
             result.NewApplicationsCount.Should().Be(entities.Count);
             result.EmployerReviewedApplicationsCount.Should().Be(0);
-            repositoryMock.Verify(repo => repo.GetAllByUkprn(ukprn, status.ToString(), token), Times.Once);
+            repositoryMock.Verify(repo => repo.GetAllByUkprn(ukprn, token), Times.Once);
         }
 
-        [Test, MoqAutoData]
+        [Test]
+        [MoqInlineAutoData(ApplicationReviewStatus.EmployerUnsuccessful)]
+        [MoqInlineAutoData(ApplicationReviewStatus.EmployerInterviewing)]
         public async Task GettingDashboardByUkprn_Given_Status_Submitted_And_ReviewDate__Not_Null_ShouldReturnDashboard(
-            int ukprn,
             ApplicationReviewStatus status,
+            int ukprn,
             CancellationToken token,
             List<ApplicationReviewEntity> entities,
             [Frozen] Mock<IApplicationReviewRepository> repositoryMock,
             [Greedy] ApplicationReviewsProvider provider)
         {
             // Arrange
-            status = ApplicationReviewStatus.Interviewing;
             foreach (var entity in entities)
             {
                 entity.Status = status.ToString();
-                entity.ReviewedDate = DateTime.Now;
-                entity.WithdrawnDate = null;
             }
-            repositoryMock.Setup(repo => repo.GetAllByUkprn(ukprn, status.ToString(), token))
+            repositoryMock.Setup(repo => repo.GetAllByUkprn(ukprn, token))
                 .ReturnsAsync(entities);
             // Act
-            var result = await provider.GetCountByUkprn(ukprn, status, token);
+            var result = await provider.GetCountByUkprn(ukprn, token);
 
             // Assert
-            result.NewApplicationsCount.Should().Be(0);
             result.EmployerReviewedApplicationsCount.Should().Be(entities.Count);
-            repositoryMock.Verify(repo => repo.GetAllByUkprn(ukprn, status.ToString(), token), Times.Once);
+            repositoryMock.Verify(repo => repo.GetAllByUkprn(ukprn, token), Times.Once);
         }
     }
 }

--- a/src/Recruit.Api.UnitTests/Controllers/EmployerAccountControllerTests/WhenGettingDashboardCountByAccountId.cs
+++ b/src/Recruit.Api.UnitTests/Controllers/EmployerAccountControllerTests/WhenGettingDashboardCountByAccountId.cs
@@ -20,11 +20,11 @@ namespace SFA.DAS.Recruit.Api.UnitTests.Controllers.EmployerAccountControllerTes
             [Greedy] EmployerAccountController controller)
         {
             // Arrange
-            providerMock.Setup(p => p.GetCountByAccountId(accountId, status , token))
+            providerMock.Setup(p => p.GetCountByAccountId(accountId, token))
                 .ReturnsAsync(mockResponse);
 
             // Act
-            var result = await controller.GetDashboardCountByAccountId(accountId, status, token);
+            var result = await controller.GetDashboardCountByAccountId(accountId, token);
 
             // Assert
             result.Should().BeOfType<Ok<DashboardModel>>();
@@ -45,11 +45,11 @@ namespace SFA.DAS.Recruit.Api.UnitTests.Controllers.EmployerAccountControllerTes
         {
             // Arrange
             // Arrange
-            providerMock.Setup(p => p.GetCountByAccountId(accountId, status, token))
+            providerMock.Setup(p => p.GetCountByAccountId(accountId, token))
                 .ThrowsAsync(new Exception());
 
             // Act
-            var result = await controller.GetDashboardCountByAccountId(accountId, status, token);
+            var result = await controller.GetDashboardCountByAccountId(accountId, token);
 
             // Assert
             result.Should().BeOfType<ProblemHttpResult>();

--- a/src/Recruit.Api.UnitTests/Controllers/ProviderAccountControllerTests/WhenGettingDashboardCountByUkprn.cs
+++ b/src/Recruit.Api.UnitTests/Controllers/ProviderAccountControllerTests/WhenGettingDashboardCountByUkprn.cs
@@ -20,11 +20,11 @@ namespace SFA.DAS.Recruit.Api.UnitTests.Controllers.ProviderAccountControllerTes
             CancellationToken token)
         {
             // Arrange
-            providerMock.Setup(p => p.GetCountByUkprn(ukprn, status , token))
+            providerMock.Setup(p => p.GetCountByUkprn(ukprn, token))
                 .ReturnsAsync(mockResponse);
 
             // Act
-            var result = await controller.GetDashboardCountByUkprn(ukprn, status, token);
+            var result = await controller.GetDashboardCountByUkprn(ukprn, token);
 
             // Assert
             result.Should().BeOfType<Ok<DashboardModel>>();
@@ -45,11 +45,11 @@ namespace SFA.DAS.Recruit.Api.UnitTests.Controllers.ProviderAccountControllerTes
         {
             // Arrange
             // Arrange
-            providerMock.Setup(p => p.GetCountByUkprn(ukprn, status, token))
+            providerMock.Setup(p => p.GetCountByUkprn(ukprn, token))
                 .ThrowsAsync(new Exception());
 
             // Act
-            var result = await controller.GetDashboardCountByUkprn(ukprn, status, token);
+            var result = await controller.GetDashboardCountByUkprn(ukprn, token);
 
             // Assert
             result.Should().BeOfType<ProblemHttpResult>();

--- a/src/Recruit.Api.UnitTests/Data/ApplicationReviewRepositoryTests/WhenGettingAllByAccountId.cs
+++ b/src/Recruit.Api.UnitTests/Data/ApplicationReviewRepositoryTests/WhenGettingAllByAccountId.cs
@@ -61,7 +61,7 @@ internal class WhenGettingAllByAccountId
         context.Setup(x => x.ApplicationReviewEntities)
             .ReturnsDbSet(allApplications);
 
-        var actual = await repository.GetAllByAccountId(accountId, status.ToString(), token);
+        var actual = await repository.GetAllByAccountId(accountId, token);
 
         actual.Should().BeEquivalentTo(applicationsReviews);
     }

--- a/src/Recruit.Api.UnitTests/Data/ApplicationReviewRepositoryTests/WhenGettingAllByUkprn.cs
+++ b/src/Recruit.Api.UnitTests/Data/ApplicationReviewRepositoryTests/WhenGettingAllByUkprn.cs
@@ -61,7 +61,7 @@ internal class WhenGettingAllByUkprn
         context.Setup(x => x.ApplicationReviewEntities)
             .ReturnsDbSet(allApplications);
 
-        var actual = await repository.GetAllByUkprn(ukprn, status.ToString(), token);
+        var actual = await repository.GetAllByUkprn(ukprn, token);
 
         actual.Should().BeEquivalentTo(applicationsReviews);
     }

--- a/src/Recruit.Api/Controllers/EmployerAccountController.cs
+++ b/src/Recruit.Api/Controllers/EmployerAccountController.cs
@@ -4,7 +4,6 @@ using Microsoft.AspNetCore.Mvc;
 using SFA.DAS.Recruit.Api.Application.Providers;
 using SFA.DAS.Recruit.Api.Core;
 using SFA.DAS.Recruit.Api.Domain.Entities;
-using SFA.DAS.Recruit.Api.Domain.Enums;
 using SFA.DAS.Recruit.Api.Domain.Models;
 using SFA.DAS.Recruit.Api.Models.Mappers;
 using SFA.DAS.Recruit.Api.Models.Responses.ApplicationReview;
@@ -52,14 +51,13 @@ namespace SFA.DAS.Recruit.Api.Controllers
         [ProducesResponseType(typeof(DashboardModel), StatusCodes.Status200OK)]
         public async Task<IResult> GetDashboardCountByAccountId(
             [FromRoute][Required] long accountId,
-            [FromQuery][Required] ApplicationReviewStatus status,
             CancellationToken token = default)
         {
             try
             {
                 logger.LogInformation("Recruit API: Received query to get dashboard stats by account id : {AccountId}", accountId);
 
-                var response = await provider.GetCountByAccountId(accountId, status, token);
+                var response = await provider.GetCountByAccountId(accountId, token);
 
                 return TypedResults.Ok(response);
             }

--- a/src/Recruit.Api/Controllers/ProviderAccountController.cs
+++ b/src/Recruit.Api/Controllers/ProviderAccountController.cs
@@ -4,7 +4,6 @@ using Microsoft.AspNetCore.Mvc;
 using SFA.DAS.Recruit.Api.Application.Providers;
 using SFA.DAS.Recruit.Api.Core;
 using SFA.DAS.Recruit.Api.Domain.Entities;
-using SFA.DAS.Recruit.Api.Domain.Enums;
 using SFA.DAS.Recruit.Api.Domain.Models;
 using SFA.DAS.Recruit.Api.Models.Mappers;
 using SFA.DAS.Recruit.Api.Models.Responses.ApplicationReview;
@@ -52,14 +51,13 @@ namespace SFA.DAS.Recruit.Api.Controllers
         [ProducesResponseType(typeof(DashboardModel), StatusCodes.Status200OK)]
         public async Task<IResult> GetDashboardCountByUkprn(
             [FromRoute][Required] int ukprn,
-            [FromQuery][Required] ApplicationReviewStatus status,
             CancellationToken token = default)
         {
             try
             {
                 logger.LogInformation("Recruit API: Received query to get dashboard stats by ukprn : {ukprn}", ukprn);
 
-                var response = await provider.GetCountByUkprn(ukprn, status, token);
+                var response = await provider.GetCountByUkprn(ukprn, token);
 
                 return TypedResults.Ok(response);
             }


### PR DESCRIPTION
✨ Refactor Application Reviews API to simplify parameters

- Removed `ApplicationReviewStatus` from provider methods.
- Updated repository methods to eliminate `status` filtering.
- Adjusted `GetDashboardModel` to count based on specific statuses.
- Modified unit tests to reflect changes in method signatures.
- Cleaned up controller methods by removing unnecessary parameters.

Changes made by Balaji Jambulingam