### PR TITLE
FAI-2541 Endpoints vacancy reviews paginated list

### DIFF
--- a/src/Recruit.Api.Data/VacancyReview/VacancyReviewRepository.cs
+++ b/src/Recruit.Api.Data/VacancyReview/VacancyReviewRepository.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using SFA.DAS.Recruit.Api.Data.Models;
 using SFA.DAS.Recruit.Api.Domain.Entities;
+using SFA.DAS.Recruit.Api.Domain.Extensions;
 using SFA.DAS.Recruit.Api.Domain.Models;
 
 namespace SFA.DAS.Recruit.Api.Data.VacancyReview;
@@ -8,6 +9,21 @@ namespace SFA.DAS.Recruit.Api.Data.VacancyReview;
 public interface IVacancyReviewRepository: IReadRepository<VacancyReviewEntity, Guid>, IWriteRepository<VacancyReviewEntity, Guid>
 {
     Task<List<VacancyReviewEntity>> GetManyByVacancyReference(VacancyReference vacancyReference, CancellationToken cancellationToken);
+    Task<PaginatedList<VacancyReviewEntity>> GetAllByAccountId(long accountId,
+        int pageNumber = 1,
+        int pageSize = 10,
+        string sortColumn = nameof(VacancyReviewEntity.CreatedDate),
+        bool isAscending = false,
+        ReviewStatus reviewStatus = ReviewStatus.New,
+        CancellationToken cancellationToken = default);
+
+    Task<PaginatedList<VacancyReviewEntity>> GetAllByUkprn(int ukprn,
+        int pageNumber = 1,
+        int pageSize = 10,
+        string sortColumn = nameof(VacancyReviewEntity.CreatedDate),
+        bool isAscending = false,
+        ReviewStatus reviewStatus = ReviewStatus.New,
+        CancellationToken cancellationToken = default);
 }
 
 public class VacancyReviewRepository(IRecruitDataContext dataContext): IVacancyReviewRepository
@@ -54,5 +70,31 @@ public class VacancyReviewRepository(IRecruitDataContext dataContext): IVacancyR
             .Where(x => x.VacancyReference == vacancyReference)
             .OrderBy(x => x.CreatedDate)
             .ToListAsync(cancellationToken);
+    }
+
+    public async Task<PaginatedList<VacancyReviewEntity>> GetAllByAccountId(long accountId,
+        int pageNumber = 1,
+        int pageSize = 10,
+        string sortColumn = "CreatedDate",
+        bool isAscending = false, ReviewStatus reviewStatus = ReviewStatus.New,
+        CancellationToken cancellationToken = default)
+    {
+        var query = dataContext.VacancyReviewEntities
+            .AsNoTracking()
+            .Where(fil => fil.AccountId == accountId && fil.Status == reviewStatus);
+        return await query.GetPagedAsync(pageNumber, pageSize, sortColumn, isAscending, cancellationToken);
+    }
+
+    public async Task<PaginatedList<VacancyReviewEntity>> GetAllByUkprn(int ukprn,
+        int pageNumber = 1,
+        int pageSize = 10,
+        string sortColumn = "CreatedDate",
+        bool isAscending = false, ReviewStatus reviewStatus = ReviewStatus.New,
+        CancellationToken cancellationToken = default)
+    {
+        var query = dataContext.VacancyReviewEntities
+            .AsNoTracking()
+            .Where(fil => fil.Ukprn == ukprn && fil.Status == reviewStatus);
+        return await query.GetPagedAsync(pageNumber, pageSize, sortColumn, isAscending, cancellationToken);
     }
 }

--- a/src/Recruit.Api/Controllers/EmployerAccountController.cs
+++ b/src/Recruit.Api/Controllers/EmployerAccountController.cs
@@ -3,16 +3,19 @@ using System.Net;
 using Microsoft.AspNetCore.Mvc;
 using SFA.DAS.Recruit.Api.Application.Providers;
 using SFA.DAS.Recruit.Api.Core;
+using SFA.DAS.Recruit.Api.Data.VacancyReview;
 using SFA.DAS.Recruit.Api.Domain.Entities;
 using SFA.DAS.Recruit.Api.Domain.Models;
 using SFA.DAS.Recruit.Api.Models.Mappers;
 using SFA.DAS.Recruit.Api.Models.Responses.ApplicationReview;
+using SFA.DAS.Recruit.Api.Models.Responses.VacancyReview;
 
 namespace SFA.DAS.Recruit.Api.Controllers
 {
     [Route($"{RouteNames.Employer}/{{accountId:long}}/")]
-    public class EmployerAccountController([FromServices]
-    IApplicationReviewsProvider provider,
+    public class EmployerAccountController(
+        [FromServices] IApplicationReviewsProvider provider,
+        [FromServices] IVacancyReviewRepository vacancyReviewRepository,
         ILogger<ApplicationReviewController> logger) : ControllerBase
     {
         [HttpGet]
@@ -41,6 +44,37 @@ namespace SFA.DAS.Recruit.Api.Controllers
             catch (Exception e)
             {
                 logger.LogError(e, "Unable to Get all application reviews by account Id : An error occurred");
+                return Results.Problem(statusCode: (int)HttpStatusCode.InternalServerError);
+            }
+        }
+
+        [HttpGet]
+        [Route("vacancyReviews")]
+        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(VacancyReviewsResponse), StatusCodes.Status200OK)]
+        public async Task<IResult> GetAllVacancyReviewsByAccountId(
+            [FromRoute][Required] long accountId,
+            [FromQuery] int pageNumber = 1,
+            [FromQuery] int pageSize = 10,
+            [FromQuery] string sortColumn = nameof(VacancyReviewEntity.CreatedDate),
+            [FromQuery] bool isAscending = false,
+            [FromQuery] ReviewStatus reviewStatus = ReviewStatus.New,
+            CancellationToken token = default)
+        {
+            try
+            {
+                logger.LogInformation("Recruit API: Received query to get all vacancy reviews by account id : {AccountId}", accountId);
+
+                var response = await vacancyReviewRepository.GetAllByAccountId(accountId, pageNumber, pageSize, sortColumn, isAscending, reviewStatus, token);
+
+                var mappedResults = response.Items.Select(app => app.ToGetResponse());
+
+                return TypedResults.Ok(new VacancyReviewsResponse(response.ToPageInfo(), mappedResults));
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "Unable to Get all vacancy reviews by account Id : An error occurred");
                 return Results.Problem(statusCode: (int)HttpStatusCode.InternalServerError);
             }
         }

--- a/src/Recruit.Api/Models/Mappers/PageInfoExtensions.cs
+++ b/src/Recruit.Api/Models/Mappers/PageInfoExtensions.cs
@@ -8,4 +8,7 @@ internal static class PageInfoExtensions
 {
     public static PageInfo ToPageInfo(this PaginatedList<ApplicationReviewEntity> paginatedList) 
         => new(paginatedList.TotalCount, paginatedList.PageIndex, paginatedList.PageSize, paginatedList.TotalPages, paginatedList.HasPreviousPage, paginatedList.HasNextPage);
+
+    public static PageInfo ToPageInfo(this PaginatedList<VacancyReviewEntity> paginatedList)
+        => new(paginatedList.TotalCount, paginatedList.PageIndex, paginatedList.PageSize, paginatedList.TotalPages, paginatedList.HasPreviousPage, paginatedList.HasNextPage);
 }

--- a/src/Recruit.Api/Models/Responses/VacancyReview/VacancyReviewsResponse.cs
+++ b/src/Recruit.Api/Models/Responses/VacancyReview/VacancyReviewsResponse.cs
@@ -1,0 +1,3 @@
+﻿namespace SFA.DAS.Recruit.Api.Models.Responses.VacancyReview;
+
+public record VacancyReviewsResponse(PageInfo PageInfo, IEnumerable<Models.VacancyReview> VacancyReviews);


### PR DESCRIPTION
✨ Add vacancy review endpoints and response models

- Implemented methods in `VacancyReviewRepository` for account ID and UKPRN.
- Added new endpoints in `EmployerAccountController` for fetching reviews.
- Introduced `GetAllVacancyReviewsByUkprn` in `ProviderAccountController`.
- Created extension method for `PaginatedList<VacancyReviewEntity>`.
- Defined `VacancyReviewsResponse` model for structured responses.