### PR TITLE
FAI-2656 patch application review

### DIFF
--- a/src/Recruit.Api.Database/Tables/ApplicationReview.sql
+++ b/src/Recruit.Api.Database/Tables/ApplicationReview.sql
@@ -29,6 +29,7 @@ CREATE TABLE dbo.[ApplicationReview] (
     INDEX [IX_ApplicationReview_UkprnWithdrawnDate] NONCLUSTERED(Ukprn, WithdrawnDate),
     INDEX [IX_ApplicationReview_AccountIdWithdrawnDate] NONCLUSTERED(AccountId,WithdrawnDate),
     INDEX [IX_ApplicationReview_CandidateId] NONCLUSTERED(CandidateId),
+    INDEX [IX_ApplicationReview_ApplicationId] NONCLUSTERED(ApplicationId),
     INDEX [IX_ApplicationReview_VacancyRef] NONCLUSTERED(VacancyReference),
     INDEX [IX_ApplicationReview_Status] NONCLUSTERED(Status),
     INDEX [IX_ApplicationReview_AccountId_DateSharedWithEmployer_Status_WithdrawnDate]  NONCLUSTERED([AccountId], [DateSharedWithEmployer])  INCLUDE ([Status], [WithdrawnDate])

--- a/src/Recruit.Api/Controllers/ApplicationReviewController.cs
+++ b/src/Recruit.Api/Controllers/ApplicationReviewController.cs
@@ -143,7 +143,11 @@ public class ApplicationReviewController([FromServices] IApplicationReviewsProvi
             var applicationReview = await provider.GetById(applicationId, cancellationToken);
             if (applicationReview is null)
             {
-                return TypedResults.NotFound();
+                applicationReview = await provider.GetByApplicationId(applicationId, cancellationToken);
+                if (applicationReview is null)
+                {
+                    return TypedResults.NotFound();    
+                }
             }
             
             var entityPatchDocument = patchRequest.ToEntity();


### PR DESCRIPTION
Alter patch to get by application id if not found by id - this is to cater for legacy applications that still have old application ids.