### PR TITLE
FAI-2516 - Return all shared count for employer dashboard

### DIFF
--- a/src/Recruit.Api.Application/Providers/ApplicationReviewsProvider.cs
+++ b/src/Recruit.Api.Application/Providers/ApplicationReviewsProvider.cs
@@ -137,15 +137,13 @@ internal class ApplicationReviewsProvider(
 
     public async Task<DashboardModel> GetCountByAccountId(long accountId, CancellationToken token = default)
     {
-        var dashboardCountTask = applicationReviewRepository.GetAllByAccountId(accountId, token);
-        var sharedApplicationReviewsCountTask = applicationReviewRepository.GetSharedCountByAccountId(accountId, token);
-        var allSharedApplicationReviewsCountTask = applicationReviewRepository.GetAllSharedCountByAccountId(accountId, token);
-
-        await Task.WhenAll(dashboardCountTask, sharedApplicationReviewsCountTask, allSharedApplicationReviewsCountTask);
+        var dashboardCount = await applicationReviewRepository.GetAllByAccountId(accountId, token);
+        int sharedApplicationReviewsCount = await applicationReviewRepository.GetSharedCountByAccountId(accountId, token);
+        int allSharedApplicationReviewsCount = await applicationReviewRepository.GetAllSharedCountByAccountId(accountId, token);
         
-        var dashboardModel = (DashboardModel)dashboardCountTask.Result;
-        dashboardModel.SharedApplicationsCount = sharedApplicationReviewsCountTask.Result;
-        dashboardModel.AllSharedApplicationsCount = allSharedApplicationReviewsCountTask.Result;
+        var dashboardModel = (DashboardModel)dashboardCount;
+        dashboardModel.SharedApplicationsCount = sharedApplicationReviewsCount;
+        dashboardModel.AllSharedApplicationsCount = allSharedApplicationReviewsCount;
 
         return dashboardModel;
     }

--- a/src/Recruit.Api.Application/Providers/ApplicationReviewsProvider.cs
+++ b/src/Recruit.Api.Application/Providers/ApplicationReviewsProvider.cs
@@ -137,11 +137,15 @@ internal class ApplicationReviewsProvider(
 
     public async Task<DashboardModel> GetCountByAccountId(long accountId, CancellationToken token = default)
     {
-        var dashboardCount = await applicationReviewRepository.GetAllByAccountId(accountId, token);
-        int sharedApplicationReviewsCount = await applicationReviewRepository.GetSharedCountByAccountId(accountId, token);
+        var dashboardCountTask = applicationReviewRepository.GetAllByAccountId(accountId, token);
+        var sharedApplicationReviewsCountTask = applicationReviewRepository.GetSharedCountByAccountId(accountId, token);
+        var allSharedApplicationReviewsCountTask = applicationReviewRepository.GetAllSharedCountByAccountId(accountId, token);
 
-        var dashboardModel = (DashboardModel)dashboardCount;
-        dashboardModel.SharedApplicationsCount = sharedApplicationReviewsCount;
+        await Task.WhenAll(dashboardCountTask, sharedApplicationReviewsCountTask, allSharedApplicationReviewsCountTask);
+        
+        var dashboardModel = (DashboardModel)dashboardCountTask.Result;
+        dashboardModel.SharedApplicationsCount = sharedApplicationReviewsCountTask.Result;
+        dashboardModel.AllSharedApplicationsCount = allSharedApplicationReviewsCountTask.Result;
 
         return dashboardModel;
     }

--- a/src/Recruit.Api.Data/ApplicationReview/ApplicationReviewRepository.cs
+++ b/src/Recruit.Api.Data/ApplicationReview/ApplicationReviewRepository.cs
@@ -31,6 +31,8 @@ public interface IApplicationReviewRepository
         CancellationToken token = default);
     Task<int> GetSharedCountByAccountId(long accountId,
         CancellationToken token = default);
+    Task<int> GetAllSharedCountByAccountId(long accountId,
+        CancellationToken token = default);
     Task<PaginatedList<ApplicationReviewEntity>> GetAllSharedByAccountId(long accountId,
         int pageNumber = 1,
         int pageSize = 10,
@@ -171,6 +173,18 @@ internal class ApplicationReviewRepository(IRecruitDataContext recruitDataContex
                 appReview.AccountId == accountId &&
                 appReview.DateSharedWithEmployer != null &&
                 appReview.Status == ApplicationReviewStatus.Shared.ToString() &&
+                appReview.WithdrawnDate == null);
+
+        return await query.CountAsync(token);
+    }
+
+    public async Task<int> GetAllSharedCountByAccountId(long accountId, CancellationToken token = default)
+    {
+        var query = recruitDataContext.ApplicationReviewEntities
+            .AsNoTracking()
+            .Where(appReview =>
+                appReview.AccountId == accountId &&
+                appReview.DateSharedWithEmployer != null &&
                 appReview.WithdrawnDate == null);
 
         return await query.CountAsync(token);

--- a/src/Recruit.Api.Domain/Models/DashboardModel.cs
+++ b/src/Recruit.Api.Domain/Models/DashboardModel.cs
@@ -10,6 +10,7 @@ namespace SFA.DAS.Recruit.Api.Domain.Models
         public int SuccessfulApplicationsCount { get; init; } = 0;
         public int UnsuccessfulApplicationsCount { get; init; } = 0;
         public int SharedApplicationsCount { get; set; } = 0;
+        public int AllSharedApplicationsCount { get; set; } = 0;
         public bool HasNoApplications { get; init; } = false;
 
         public static implicit operator DashboardModel(List<DashboardCountModel> source)
@@ -18,6 +19,7 @@ namespace SFA.DAS.Recruit.Api.Domain.Models
             {
                 NewApplicationsCount = source.FirstOrDefault(c => c.Status == ApplicationReviewStatus.New)?.Count ?? 0,
                 SharedApplicationsCount = 0,
+                AllSharedApplicationsCount = 0,
                 SuccessfulApplicationsCount = source.FirstOrDefault(c => c.Status == ApplicationReviewStatus.Successful)?.Count ?? 0,
                 UnsuccessfulApplicationsCount = source.FirstOrDefault(c => c.Status == ApplicationReviewStatus.Unsuccessful)?.Count ?? 0,
                 EmployerReviewedApplicationsCount = (source.FirstOrDefault(c => c.Status == ApplicationReviewStatus.EmployerInterviewing)?.Count ?? 0)

--- a/src/Recruit.Api.UnitTests/Application/Providers/ApplicationReviewsProviderTests/WhenGettingDashboardCountByAccountId.cs
+++ b/src/Recruit.Api.UnitTests/Application/Providers/ApplicationReviewsProviderTests/WhenGettingDashboardCountByAccountId.cs
@@ -17,12 +17,14 @@ internal class WhenGettingDashboardCountByAccountId
         int employerUnsuccessfulCount,
         int employerInterviewingCount,
         int sharedCount,
+        int allSharedCount,
         CancellationToken token,
         [Frozen] Mock<IApplicationReviewRepository> repositoryMock,
         [Greedy] ApplicationReviewsProvider provider)
     {
         // Arrange
         repositoryMock.Setup(x => x.GetSharedCountByAccountId(accountId, token)).ReturnsAsync(sharedCount);
+        repositoryMock.Setup(x => x.GetAllSharedCountByAccountId(accountId, token)).ReturnsAsync(allSharedCount);
         repositoryMock.Setup(repo => repo.GetAllByAccountId(accountId, token))
             .ReturnsAsync([
                 new DashboardCountModel {
@@ -55,6 +57,7 @@ internal class WhenGettingDashboardCountByAccountId
         result.UnsuccessfulApplicationsCount.Should().Be(unsuccessfulCount);
         result.SuccessfulApplicationsCount.Should().Be(successfulCount);
         result.SharedApplicationsCount.Should().Be(sharedCount);
+        result.AllSharedApplicationsCount.Should().Be(allSharedCount);
         repositoryMock.Verify(repo => repo.GetAllByAccountId(accountId, token), Times.Once);
     }
         


### PR DESCRIPTION
Added new count to get all shared applications, where date is not null and excluding status