### PR TITLE
FAI-2424 Add Pagination Vacancy Manage Page

### DIFF
--- a/src/Recruit.Api.Application/Providers/ApplicationReviewsProvider.cs
+++ b/src/Recruit.Api.Application/Providers/ApplicationReviewsProvider.cs
@@ -59,10 +59,16 @@ public interface IApplicationReviewsProvider
         bool isAscending = false,
         List<ApplicationReviewStatus>? status = null,
         CancellationToken token = default);
+
+    Task<PaginatedList<ApplicationReviewEntity>> GetPagedByVacancyReferenceAsync(long vacancyReference,
+        int pageNumber = 1,
+        int pageSize = 10,
+        string sortColumn = nameof(ApplicationReviewEntity.CreatedDate),
+        bool isAscending = false,
+        CancellationToken token = default);
 }
 
-internal class ApplicationReviewsProvider(
-    IApplicationReviewRepository applicationReviewRepository) : IApplicationReviewsProvider
+internal class ApplicationReviewsProvider(IApplicationReviewRepository applicationReviewRepository) : IApplicationReviewsProvider
 {
     public async Task<ApplicationReviewEntity?> GetById(Guid id, CancellationToken token = default)
     {
@@ -113,6 +119,17 @@ internal class ApplicationReviewsProvider(
         var vacancyDetails = GetVacancyDetails(appReviews.Items);
         return new PaginatedList<VacancyDetail>(vacancyDetails, appReviews.TotalCount, appReviews.PageIndex,
             appReviews.PageSize);
+    }
+
+    public async Task<PaginatedList<ApplicationReviewEntity>> GetPagedByVacancyReferenceAsync(long vacancyReference,
+        int pageNumber = 1,
+        int pageSize = 10,
+        string sortColumn = nameof(ApplicationReviewEntity.CreatedDate),
+        bool isAscending = false,
+        CancellationToken token = default)
+    {
+        return await applicationReviewRepository.GetPagedByVacancyReference(vacancyReference, pageNumber, pageSize,
+            sortColumn, isAscending, token);
     }
 
     public async Task<PaginatedList<ApplicationReviewEntity>> GetPagedAccountIdAsync(long accountId,

--- a/src/Recruit.Api.UnitTests/Application/Providers/ApplicationReviewsProviderTests/WhenGettingPagedByVacancyReference.cs
+++ b/src/Recruit.Api.UnitTests/Application/Providers/ApplicationReviewsProviderTests/WhenGettingPagedByVacancyReference.cs
@@ -1,0 +1,55 @@
+﻿using SFA.DAS.Recruit.Api.Application.Providers;
+using SFA.DAS.Recruit.Api.Data.ApplicationReview;
+using SFA.DAS.Recruit.Api.Domain.Entities;
+using SFA.DAS.Recruit.Api.Domain.Models;
+
+namespace SFA.DAS.Recruit.Api.UnitTests.Application.Providers.ApplicationReviewsProviderTests;
+[TestFixture]
+internal class WhenGettingPagedByVacancyReference
+{
+    [Test, MoqAutoData]
+    public async Task GetPagedByVacancyReferenceAsync_CallsRepositoryWithCorrectParameters(
+        long vacancyReference,
+        List<ApplicationReviewEntity> applicationReviews,
+        [Frozen] Mock<IApplicationReviewRepository> repository,
+        [Greedy] ApplicationReviewsProvider provider)
+    {
+        // Arrange
+        int pageNumber = 2;
+        int pageSize = 5;
+        string sortColumn = nameof(ApplicationReviewEntity.CreatedDate);
+        bool isAscending = true;
+        var token = CancellationToken.None;
+        var pagedList = new PaginatedList<ApplicationReviewEntity>(applicationReviews, applicationReviews.Count, pageNumber, pageSize);
+
+        repository.Setup(r => r.GetPagedByVacancyReference(vacancyReference, pageNumber, pageSize, sortColumn, isAscending, token))
+            .ReturnsAsync(pagedList);
+
+        // Act
+        var result = await provider.GetPagedByVacancyReferenceAsync(vacancyReference, pageNumber, pageSize, sortColumn, isAscending, token);
+
+        // Assert
+        result.Should().BeEquivalentTo(pagedList);
+        repository.Verify(r => r.GetPagedByVacancyReference(vacancyReference, pageNumber, pageSize, sortColumn, isAscending, token), Times.Once);
+    }
+
+    [Test, MoqAutoData]
+    public async Task GetPagedByVacancyReferenceAsync_UsesDefaultParameters(
+        long vacancyReference,
+        [Frozen] Mock<IApplicationReviewRepository> repository,
+        [Greedy] ApplicationReviewsProvider provider)
+    {
+        // Arrange
+        var pagedList = new PaginatedList<ApplicationReviewEntity>([], 0, 1, 10);
+
+        repository.Setup(r => r.GetPagedByVacancyReference(vacancyReference, 1, 10, nameof(ApplicationReviewEntity.CreatedDate), false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(pagedList);
+
+        // Act
+        var result = await provider.GetPagedByVacancyReferenceAsync(vacancyReference);
+
+        // Assert
+        result.Should().BeEquivalentTo(pagedList);
+        repository.Verify(r => r.GetPagedByVacancyReference(vacancyReference, 1, 10, nameof(ApplicationReviewEntity.CreatedDate), false, It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/src/Recruit.Api.UnitTests/Controllers/ApplicationReviewControllerTests/WhenGettingPaginatedApplicationReviewsByVacancyReference.cs
+++ b/src/Recruit.Api.UnitTests/Controllers/ApplicationReviewControllerTests/WhenGettingPaginatedApplicationReviewsByVacancyReference.cs
@@ -1,0 +1,72 @@
+﻿using System.Net;
+using Microsoft.AspNetCore.Http.HttpResults;
+using SFA.DAS.Recruit.Api.Application.Providers;
+using SFA.DAS.Recruit.Api.Controllers;
+using SFA.DAS.Recruit.Api.Domain.Entities;
+using SFA.DAS.Recruit.Api.Domain.Models;
+using SFA.DAS.Recruit.Api.Models.Responses.ApplicationReview;
+
+namespace SFA.DAS.Recruit.Api.UnitTests.Controllers.ApplicationReviewControllerTests;
+[TestFixture]
+internal class WhenGettingPaginatedApplicationReviewsByVacancyReference
+{
+    [Test, MoqAutoData]
+    public async Task GetAllByVacancyReference_ReturnsOk_WhenApplicationReviewsExist(
+        long vacancyReference,
+        int pageNumber,
+        int pageSize,
+        string sortColumn,
+        bool isAscending,
+        List<ApplicationReviewEntity> mockResponse,
+        [Frozen] Mock<IApplicationReviewsProvider> providerMock,
+        [Greedy] ApplicationReviewController controller,
+        CancellationToken token)
+    {
+        // Arrange
+        var pagedResult = new PaginatedList<ApplicationReviewEntity>(mockResponse.ToList(), 1, pageNumber, pageSize);
+        providerMock.Setup(p => p.GetPagedByVacancyReferenceAsync(vacancyReference, pageNumber, pageSize, sortColumn, isAscending, token))
+                    .ReturnsAsync(pagedResult);
+
+        // Act
+        var result = await controller.GetPagedByVacancyReference(vacancyReference, pageNumber, pageSize, sortColumn, isAscending, token);
+
+        // Assert
+        result.Should().BeOfType<Ok<GetPagedApplicationReviewsResponse>>();
+        var okResult = result as Ok<GetPagedApplicationReviewsResponse>;
+
+        okResult!.StatusCode.Should().Be((int)HttpStatusCode.OK);
+        okResult.Value!.Items.Count().Should().Be(mockResponse.Count);
+    }
+
+    [Test, MoqAutoData]
+    public async Task GetAllByVacancyReference_Returns_Empty_WhenNoApplicationReviewsExist(
+        long vacancyReference,
+        int pageNumber,
+        int pageSize,
+        string sortColumn,
+        bool isAscending,
+        List<ApplicationReviewEntity> mockResponse,
+        [Frozen] Mock<IApplicationReviewsProvider> providerMock,
+        [Greedy] ApplicationReviewController controller,
+        CancellationToken token)
+    {
+        // Arrange
+        var pagedResult = new PaginatedList<ApplicationReviewEntity>([], 0, pageNumber, pageSize);
+        providerMock.Setup(p => p.GetPagedByVacancyReferenceAsync(vacancyReference, pageNumber, pageSize, sortColumn, isAscending, token))
+            .ReturnsAsync(pagedResult);
+
+        // Act
+        var result = await controller.GetPagedByVacancyReference(vacancyReference, pageNumber, pageSize, sortColumn, isAscending, token);
+
+        // Assert
+        result.Should().BeOfType<Ok<GetPagedApplicationReviewsResponse>>();
+        var okResult = result as Ok<GetPagedApplicationReviewsResponse>;
+
+        okResult!.StatusCode.Should().Be((int)HttpStatusCode.OK);
+        okResult.Value!.Items.Count().Should().Be(0);
+        okResult.Value!.Info.TotalCount.Should().Be(0);
+        okResult.Value!.Info.PageIndex.Should().Be(pageNumber);
+        okResult.Value!.Info.PageSize.Should().Be(pageSize);
+        okResult.Value!.Info.TotalPages.Should().Be(0);
+    }
+}

--- a/src/Recruit.Api.UnitTests/Data/ApplicationReviewRepositoryTests/WhenGettingPagedByVacancyReference.cs
+++ b/src/Recruit.Api.UnitTests/Data/ApplicationReviewRepositoryTests/WhenGettingPagedByVacancyReference.cs
@@ -1,0 +1,34 @@
+﻿using SFA.DAS.Recruit.Api.Data;
+using SFA.DAS.Recruit.Api.Data.ApplicationReview;
+using SFA.DAS.Recruit.Api.Domain.Entities;
+using SFA.DAS.Recruit.Api.UnitTests.Data.DatabaseMock;
+
+namespace SFA.DAS.Recruit.Api.UnitTests.Data.ApplicationReviewRepositoryTests;
+[TestFixture]
+internal class WhenGettingPagedByVacancyReference
+{
+    [Test, RecursiveMoqAutoData]
+    public async Task GettingPagedByVacancyReference(
+        long vacancyReference,
+        CancellationToken token,
+        List<ApplicationReviewEntity> entities,
+        [Frozen] Mock<IRecruitDataContext> context,
+        [Greedy] ApplicationReviewRepository repository)
+    {
+        // Arrange
+        foreach (var applicationReviewEntity in entities)
+        {
+            applicationReviewEntity.VacancyReference = vacancyReference;
+        }
+
+        context.Setup(x => x.ApplicationReviewEntities)
+            .ReturnsDbSet(entities);
+
+        // Act
+        var result = await repository.GetPagedByVacancyReference(vacancyReference, 1, 10, "CreatedDate", true, token);
+
+        // Assert
+        result.Items.Should().BeEquivalentTo(entities);
+        result.TotalCount.Should().Be(entities.Count);
+    }
+}

--- a/src/Recruit.Api/Models/Responses/ApplicationReview/GetPagedApplicationReviewsResponse.cs
+++ b/src/Recruit.Api/Models/Responses/ApplicationReview/GetPagedApplicationReviewsResponse.cs
@@ -1,0 +1,5 @@
+﻿using SFA.DAS.Recruit.Api.Domain.Entities;
+
+namespace SFA.DAS.Recruit.Api.Models.Responses.ApplicationReview;
+
+public record GetPagedApplicationReviewsResponse(PageInfo Info, IEnumerable<ApplicationReviewEntity> Items);


### PR DESCRIPTION
✨ Add paginated retrieval for application reviews

- Updated `IApplicationReviewsProvider` with `GetPagedByVacancyReferenceAsync`.
- Implemented pagination in `ApplicationReviewsProvider` for reviews.
- Added `GetPagedByVacancyReference` to `IApplicationReviewRepository`.
- Created a new endpoint in `ApplicationReviewController` for paginated reviews.
- Added unit tests to verify new functionality in provider and controller.

Changes made by Balaji Jambulingam