### PR TITLE
FAI-2766 use vacancy rather than vacancy reviews

### DIFF
--- a/src/Recruit.Api.Application/Providers/ApplicationReviewsProvider.cs
+++ b/src/Recruit.Api.Application/Providers/ApplicationReviewsProvider.cs
@@ -33,10 +33,19 @@ public interface IApplicationReviewsProvider
 
     Task<UpsertResult<ApplicationReviewEntity>> Upsert(ApplicationReviewEntity entity, CancellationToken token = default);
 
-    Task<List<ApplicationReviewsStats>> GetVacancyReferencesCountByAccountId(long accountId, List<long> vacancyReferences, ApplicationReviewStatus? applicationSharedFilteringStatus = null, CancellationToken token = default);
-    Task<List<ApplicationReviewsStats>> GetVacancyReferencesCountByUkprn(int ukprn, List<long> vacancyReferences, CancellationToken token = default);
+    Task<List<ApplicationReviewsStats>> GetVacancyReferencesCountByAccountId(long accountId,
+        List<long> vacancyReferences,
+        ApplicationReviewStatus? applicationSharedFilteringStatus = null,
+        CancellationToken token = default);
+
+    Task<List<ApplicationReviewsStats>> GetVacancyReferencesCountByUkprn(int ukprn,
+        List<long> vacancyReferences,
+        CancellationToken token = default);
+
     Task<List<ApplicationReviewEntity>> GetAllByVacancyReference(long vacancyReference, CancellationToken token = default);
+
     Task<ApplicationReviewEntity?> GetByApplicationId(Guid applicationId, CancellationToken token = default);
+
     Task<PaginatedList<VacancyDetail>> GetPagedByAccountAndStatusAsync(long accountId,
         int pageNumber = 1,
         int pageSize = 10,
@@ -68,7 +77,7 @@ internal class ApplicationReviewsProvider(
     {
         return await applicationReviewRepository.GetById(id, token);
     }
-    
+
     public async Task<ApplicationReviewEntity?> GetByApplicationId(Guid applicationId, CancellationToken token = default)
     {
         return await applicationReviewRepository.GetByApplicationId(applicationId, token);
@@ -140,7 +149,7 @@ internal class ApplicationReviewsProvider(
         var dashboardCount = await applicationReviewRepository.GetAllByAccountId(accountId, token);
         int sharedApplicationReviewsCount = await applicationReviewRepository.GetSharedCountByAccountId(accountId, token);
         int allSharedApplicationReviewsCount = await applicationReviewRepository.GetAllSharedCountByAccountId(accountId, token);
-        
+
         var dashboardModel = (DashboardModel)dashboardCount;
         dashboardModel.SharedApplicationsCount = sharedApplicationReviewsCount;
         dashboardModel.AllSharedApplicationsCount = allSharedApplicationReviewsCount;
@@ -163,26 +172,14 @@ internal class ApplicationReviewsProvider(
         return await applicationReviewRepository.Upsert(entity, token);
     }
 
-    public async Task<List<ApplicationReviewsStats>> GetVacancyReferencesCountByAccountId(long accountId, List<long> vacancyReferences,ApplicationReviewStatus? applicationSharedFilteringStatus,
+    public async Task<List<ApplicationReviewsStats>> GetVacancyReferencesCountByAccountId(long accountId, List<long> vacancyReferences, ApplicationReviewStatus? applicationSharedFilteringStatus,
         CancellationToken token = default)
     {
-        List<ApplicationReviewEntity> applicationReviews;
-        if (applicationSharedFilteringStatus is ApplicationReviewStatus.Shared or ApplicationReviewStatus.AllShared)
-        {
-            if (applicationSharedFilteringStatus == ApplicationReviewStatus.AllShared)
-            {
-                applicationReviews  = await applicationReviewRepository.GetAllSharedByAccountId(accountId,vacancyReferences, token);    
-            }
-            else
-            {
-                applicationReviews  = await applicationReviewRepository.GetNewSharedByAccountId(accountId, vacancyReferences,token);    
-            }
-        }
-        else
-        {
-            applicationReviews  = await applicationReviewRepository.GetByAccountIdAndVacancyReferencesAsync(accountId, vacancyReferences, token);
-        }
-        
+        var applicationReviews = applicationSharedFilteringStatus is ApplicationReviewStatus.Shared or ApplicationReviewStatus.AllShared
+            ? applicationSharedFilteringStatus == ApplicationReviewStatus.AllShared
+                ? await applicationReviewRepository.GetAllSharedByAccountId(accountId, vacancyReferences, token)
+                : await applicationReviewRepository.GetNewSharedByAccountId(accountId, vacancyReferences, token)
+            : await applicationReviewRepository.GetByAccountIdAndVacancyReferencesAsync(accountId, vacancyReferences, token);
 
         return GetApplicationReviewsStats(vacancyReferences, applicationReviews);
     }
@@ -210,8 +207,7 @@ internal class ApplicationReviewsProvider(
                 (vacancyRef, reviews) =>
                 {
                     var applicationReviewEntities = reviews.ToList();
-                    return new ApplicationReviewsStats
-                    {
+                    return new ApplicationReviewsStats {
                         VacancyReference = vacancyRef,
                         NewApplications = applicationReviewEntities.New(),
                         SharedApplications = applicationReviewEntities.Shared(),
@@ -245,12 +241,11 @@ internal class ApplicationReviewsProvider(
                     ar.WithdrawnDate == null);
 
                 int allSharedApplications = g.Count(ar =>
-                    ar is {DateSharedWithEmployer: not null, WithdrawnDate: null});
+                    ar is { DateSharedWithEmployer: not null, WithdrawnDate: null });
 
                 int applications = g.Count(ar => ar.WithdrawnDate == null);
 
-                return new VacancyDetail
-                {
+                return new VacancyDetail {
                     VacancyReference = g.Key,
                     NewApplications = newApplications,
                     Applications = applications,

--- a/src/Recruit.Api.Data/ApplicationReview/ApplicationReviewRepository.cs
+++ b/src/Recruit.Api.Data/ApplicationReview/ApplicationReviewRepository.cs
@@ -54,7 +54,6 @@ public interface IApplicationReviewRepository
     Task<List<ApplicationReviewEntity>> GetByAccountIdAndVacancyReferencesAsync(long accountId, List<long> vacancyReferences, CancellationToken token = default);
     Task<ApplicationReviewEntity?> GetByApplicationId(Guid applicationId, CancellationToken token = default);
     Task<List<ApplicationReviewEntity>> GetAllByVacancyReference(long vacancyReference, CancellationToken token = default);
-
     Task<List<ApplicationReviewEntity>> GetNewSharedByAccountId(long accountId, List<long> vacancyReferences,CancellationToken token = default);
     Task<List<ApplicationReviewEntity>> GetAllSharedByAccountId(long accountId,List<long> vacancyReferences, CancellationToken token = default);
 }
@@ -125,13 +124,10 @@ internal class ApplicationReviewRepository(IRecruitDataContext recruitDataContex
             .AsNoTracking()
             .Where(appReview => appReview.AccountId == accountId && statusStrings.Contains(appReview.Status) && appReview.WithdrawnDate == null) 
             .Join(
-                recruitDataContext.VacancyReviewEntities.AsNoTracking()
-                    .Where(vacancyReview =>
-                        vacancyReview.Status == ReviewStatus.Closed &&
-                        vacancyReview.ManualOutcome == "Approved" &&
-                        ownerTypes.Contains(vacancyReview.OwnerType)),
+                recruitDataContext.VacancyEntities.AsNoTracking()
+                    .Where(vacancy => ownerTypes.Contains((OwnerType)vacancy.OwnerType!)),
                 appReview => appReview.VacancyReference,
-                vacancyReview => vacancyReview.VacancyReference,
+                vacancy => vacancy.VacancyReference,
                 (appReview, _) => appReview
             );
         
@@ -151,13 +147,10 @@ internal class ApplicationReviewRepository(IRecruitDataContext recruitDataContex
             .AsNoTracking()
             .Where(appReview => appReview.AccountId == accountId && appReview.DateSharedWithEmployer != null && appReview.WithdrawnDate == null)
             .Join(
-                recruitDataContext.VacancyReviewEntities.AsNoTracking()
-                    .Where(vacancyReview =>
-                        vacancyReview.Status == ReviewStatus.Closed &&
-                        vacancyReview.ManualOutcome == "Approved"),
+                recruitDataContext.VacancyEntities.AsNoTracking(),
                 appReview => appReview.VacancyReference,
-                vacancyReview => vacancyReview.VacancyReference,
-                (appReview, vacancyReview) => appReview
+                vacancy => vacancy.VacancyReference,
+                (appReview, vacancy) => appReview
             );
         
         var groupedCountQuery = await query.GroupBy(c => c.VacancyReference).CountAsync(cancellationToken: token);
@@ -233,17 +226,13 @@ internal class ApplicationReviewRepository(IRecruitDataContext recruitDataContex
         .AsNoTracking()
             .Where(appReview => appReview.Ukprn == ukprn && statusStrings.Contains(appReview.Status) && appReview.WithdrawnDate == null)
             .Join(
-                recruitDataContext.VacancyReviewEntities.AsNoTracking()
-                    .Where(vacancyReview =>
-                        vacancyReview.Status == ReviewStatus.Closed &&
-                        vacancyReview.ManualOutcome == "Approved" &&
-                        vacancyReview.OwnerType == OwnerType.Provider),
+                recruitDataContext.VacancyEntities.AsNoTracking()
+                    .Where(vacancy => vacancy.OwnerType == OwnerType.Provider),
                 appReview => appReview.VacancyReference,
-                vacancyReview => vacancyReview.VacancyReference,
-                (appReview, _) => appReview
-            );
+                vacancy => vacancy.VacancyReference,
+                (appReview, _) => appReview);
 
-        var groupedCountQuery = await query.GroupBy(c => c.VacancyReference).CountAsync(cancellationToken: token);
+        int groupedCountQuery = await query.GroupBy(c => c.VacancyReference).CountAsync(cancellationToken: token);
 
         return await query.GetPagedAsync(pageNumber, pageSize, sortColumn, isAscending, groupedCountQuery, token);
     }
@@ -297,18 +286,17 @@ internal class ApplicationReviewRepository(IRecruitDataContext recruitDataContex
             .AsNoTracking()
             .Where(appReview => appReview.AccountId == accountId && appReview.WithdrawnDate == null)
             .Join(
-                recruitDataContext.VacancyReviewEntities.AsNoTracking()
-                    .Where(vacancyReview =>
-                        vacancyReview.Status == ReviewStatus.Closed &&
-                        vacancyReview.ManualOutcome == "Approved" &&
-                        vacancyReview.OwnerType == OwnerType.Employer),
+                recruitDataContext.VacancyEntities.AsNoTracking()
+                    .Where(vacancy => vacancy.OwnerType == OwnerType.Employer),
                 appReview => appReview.VacancyReference,
-                vacancyReview => vacancyReview.VacancyReference,
+                vacancy => vacancy.VacancyReference,
                 (appReview, _) => appReview
-            ).GroupBy(c => c.Status).Select(g => new DashboardCountModel {
-                Status = Enum.Parse<ApplicationReviewStatus>(g.Key.ToString(), true),
-                Count = g.Count()
-            })
+            ).GroupBy(c => c.Status).Select(g => 
+                new DashboardCountModel
+                {
+                    Status = Enum.Parse<ApplicationReviewStatus>(g.Key.ToString(), true),
+                    Count = g.Count()
+                })
             .ToListAsync(token);
     }
 
@@ -318,15 +306,14 @@ internal class ApplicationReviewRepository(IRecruitDataContext recruitDataContex
         .AsNoTracking()
             .Where(appReview => appReview.Ukprn == ukprn && appReview.WithdrawnDate == null)
             .Join(
-                recruitDataContext.VacancyReviewEntities.AsNoTracking()
-                    .Where(vacancyReview =>
-                        vacancyReview.Status == ReviewStatus.Closed &&
-                        vacancyReview.ManualOutcome == "Approved" &&
-                        vacancyReview.OwnerType == OwnerType.Provider),
+                recruitDataContext.VacancyEntities.AsNoTracking()
+                    .Where(vacancy => vacancy.OwnerType == OwnerType.Provider),
                 appReview => appReview.VacancyReference,
-                vacancyReview => vacancyReview.VacancyReference,
+                vacancy => vacancy.VacancyReference,
                 (appReview, _) => appReview
-            ).GroupBy(c => c.Status).Select(g => new DashboardCountModel {
+            ).GroupBy(c => c.Status).Select(g => 
+            new DashboardCountModel
+            {
                 Status = Enum.Parse<ApplicationReviewStatus>(g.Key.ToString(), true),
                 Count = g.Count()
             })
@@ -344,13 +331,10 @@ internal class ApplicationReviewRepository(IRecruitDataContext recruitDataContex
             .AsNoTracking()
             .Where(appReview => appReview.AccountId == accountId && vacancyReferences.Contains(appReview.VacancyReference))
             .Join(
-                recruitDataContext.VacancyReviewEntities.AsNoTracking()
-                    .Where(vacancyReview =>
-                        vacancyReview.Status == ReviewStatus.Closed &&
-                        vacancyReview.ManualOutcome == "Approved" &&
-                        vacancyReview.OwnerType == OwnerType.Employer),
+                recruitDataContext.VacancyEntities.AsNoTracking()
+                    .Where(vacancy => vacancy.OwnerType == OwnerType.Employer),
                 appReview => appReview.VacancyReference,
-                vacancyReview => vacancyReview.VacancyReference,
+                vacancy => vacancy.VacancyReference,
                 (appReview, _) => appReview
             )
             .ToListAsync(token);
@@ -367,13 +351,10 @@ internal class ApplicationReviewRepository(IRecruitDataContext recruitDataContex
             .AsNoTracking()
             .Where(appReview => appReview.Ukprn == ukprn && vacancyReferences.Contains(appReview.VacancyReference))
             .Join(
-                recruitDataContext.VacancyReviewEntities.AsNoTracking()
-                    .Where(vacancyReview =>
-                        vacancyReview.Status == ReviewStatus.Closed &&
-                        vacancyReview.ManualOutcome == "Approved" &&
-                        vacancyReview.OwnerType == OwnerType.Provider),
+                recruitDataContext.VacancyEntities.AsNoTracking()
+                    .Where(vacancy => vacancy.OwnerType == OwnerType.Provider),
                 appReview => appReview.VacancyReference,
-                vacancyReview => vacancyReview.VacancyReference,
+                vacancy => vacancy.VacancyReference,
                 (appReview, _) => appReview
             )
             .ToListAsync(token);

--- a/src/Recruit.Api.Data/ApplicationReview/ApplicationReviewRepository.cs
+++ b/src/Recruit.Api.Data/ApplicationReview/ApplicationReviewRepository.cs
@@ -224,7 +224,10 @@ internal class ApplicationReviewRepository(IRecruitDataContext recruitDataContex
 
         var query = recruitDataContext.ApplicationReviewEntities
         .AsNoTracking()
-            .Where(appReview => appReview.Ukprn == ukprn && statusStrings.Contains(appReview.Status) && appReview.WithdrawnDate == null)
+            .Where(appReview =>
+                appReview.Ukprn == ukprn &&
+                statusStrings.Contains(appReview.Status) &&
+                appReview.WithdrawnDate == null)
             .Join(
                 recruitDataContext.VacancyEntities.AsNoTracking()
                     .Where(vacancy => vacancy.OwnerType == OwnerType.Provider),
@@ -232,7 +235,10 @@ internal class ApplicationReviewRepository(IRecruitDataContext recruitDataContex
                 vacancy => vacancy.VacancyReference,
                 (appReview, _) => appReview);
 
-        int groupedCountQuery = await query.GroupBy(c => c.VacancyReference).CountAsync(cancellationToken: token);
+        int groupedCountQuery = await query
+            .Select(c => c.VacancyReference)
+            .Distinct()
+            .CountAsync(cancellationToken: token);
 
         return await query.GetPagedAsync(pageNumber, pageSize, sortColumn, isAscending, groupedCountQuery, token);
     }

--- a/src/Recruit.Api.IntegrationTests/Controllers/VacancyControllerTests/WhenPostingVacancy.cs
+++ b/src/Recruit.Api.IntegrationTests/Controllers/VacancyControllerTests/WhenPostingVacancy.cs
@@ -57,7 +57,9 @@ public class WhenPostingVacancy: BaseFixture
         var vacancy = await response.Content.ReadAsAsync<Vacancy>();
 
         // assert
-        vacancy.Should().BeEquivalentTo(request, opt => opt.Excluding(x => x.SubmittedByUserId));
+        vacancy.Should().BeEquivalentTo(request, opt => opt
+            .Excluding(x => x.SubmittedByUserId)
+            .Excluding(x => x.ReviewRequestedByUserId));
         vacancy.Id.Should().Be(id);
         vacancy.VacancyReference.Should().Be(vacancyReference.Value);
         

--- a/src/Recruit.Api.IntegrationTests/Controllers/VacancyControllerTests/WhenPuttingVacancy.cs
+++ b/src/Recruit.Api.IntegrationTests/Controllers/VacancyControllerTests/WhenPuttingVacancy.cs
@@ -50,7 +50,10 @@ public class WhenPuttingVacancy: BaseFixture
         var vacancy = await response.Content.ReadAsAsync<Vacancy>();
 
         // assert
-        vacancy.Should().BeEquivalentTo(request, opt => opt.Excluding(x => x.SubmittedByUserId));
+        vacancy.Should().BeEquivalentTo(request, opt => opt
+            .Excluding(x => x.SubmittedByUserId)
+            .Excluding(x => x.ReviewRequestedByUserId)
+        );
         
         response.StatusCode.Should().Be(HttpStatusCode.Created);
         response.Headers.Location.Should().NotBeNull();
@@ -82,7 +85,9 @@ public class WhenPuttingVacancy: BaseFixture
 
         // assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        vacancy.Should().BeEquivalentTo(request, opt => opt.Excluding(x => x.SubmittedByUserId));
+        vacancy.Should().BeEquivalentTo(request, opt => opt
+            .Excluding(x => x.SubmittedByUserId)
+            .Excluding(x => x.ReviewRequestedByUserId));
 
         Server.DataContext.Verify(x => x.SetValues(targetItem, ItIs.EquivalentTo(request.ToDomain(targetItem.Id))), Times.Once());
         Server.DataContext.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);

--- a/src/Recruit.Api.UnitTests/Data/ApplicationReviewRepositoryTests/WhenGettingAllByAccountId.cs
+++ b/src/Recruit.Api.UnitTests/Data/ApplicationReviewRepositoryTests/WhenGettingAllByAccountId.cs
@@ -54,7 +54,7 @@ internal class WhenGettingAllByAccountId
         long vacancyReference,
         CancellationToken token,
         List<ApplicationReviewEntity> applicationsReviews,
-        List<VacancyReviewEntity> vacancyReviewEntities,
+        List<VacancyEntity> vacancyEntities,
         [Frozen] Mock<IRecruitDataContext> context,
         [Greedy] ApplicationReviewRepository repository)
     {
@@ -66,8 +66,8 @@ internal class WhenGettingAllByAccountId
 
         context.Setup(x => x.ApplicationReviewEntities)
             .ReturnsDbSet(applicationsReviews);
-        context.Setup(x => x.VacancyReviewEntities)
-            .ReturnsDbSet(vacancyReviewEntities);
+        context.Setup(x => x.VacancyEntities)
+            .ReturnsDbSet(vacancyEntities);
 
         var actual = await repository.GetByAccountIdAndVacancyReferencesAsync(accountId, [vacancyReference], token);
 

--- a/src/Recruit.Api.UnitTests/Data/ApplicationReviewRepositoryTests/WhenGettingAllByUkprn.cs
+++ b/src/Recruit.Api.UnitTests/Data/ApplicationReviewRepositoryTests/WhenGettingAllByUkprn.cs
@@ -53,7 +53,7 @@ internal class WhenGettingAllByUkprn
         long vacancyReference,
         CancellationToken token,
         List<ApplicationReviewEntity> applicationsReviews,
-        List<VacancyReviewEntity> vacancyReviewEntities,
+        List<VacancyEntity> vacancyEntities,
         [Frozen] Mock<IRecruitDataContext> context,
         [Greedy] ApplicationReviewRepository repository)
     {
@@ -66,8 +66,8 @@ internal class WhenGettingAllByUkprn
 
         context.Setup(x => x.ApplicationReviewEntities)
             .ReturnsDbSet(applicationsReviews);
-        context.Setup(x => x.VacancyReviewEntities)
-            .ReturnsDbSet(vacancyReviewEntities);
+        context.Setup(x => x.VacancyEntities)
+            .ReturnsDbSet(vacancyEntities);
 
         var actual = await repository.GetByUkprnAndVacancyReferencesAsync(ukprn, [vacancyReference], token);
 


### PR DESCRIPTION
✨ Update ApplicationReviewRepository and tests

* Removed `GetNewSharedByAccountId` from `IApplicationReviewRepository`.
* Added `GetAllByUkprn` method to the repository interface.
* Updated joins in `ApplicationReviewRepository` to use `VacancyEntities`.
* Changed `groupedCountQuery` type from `var` to `int` for clarity.
* Modified tests to exclude `ReviewRequestedByUserId` and use `VacancyEntity`.

Changes made by Balaji Jambulingam