### PR TITLE
FAI-3444 Submitter Details not recorded on VacancyReview

### DIFF
--- a/src/Recruit.Api.IntegrationTests/Controllers/VacancyControllerTests/WhenPostingVacancy.cs
+++ b/src/Recruit.Api.IntegrationTests/Controllers/VacancyControllerTests/WhenPostingVacancy.cs
@@ -81,15 +81,18 @@ public class WhenPostingVacancy: BaseFixture
     }
     
     [Test]
-    public async Task Then_The_Vacancy_Is_Added()
+    public async Task Then_The_Vacancy_Is_Added_User_Already_Exist()
     {
         // arrange
         var vacancyReference = Fixture.Create<VacancyReference>();
         var request = Fixture.Create<SFA.DAS.Recruit.Contracts.ApiResponses.PostVacancyRequest>();
+        var userEntity = Fixture.Create<UserEntity>();
+
+        request.SubmittedByUserId = userEntity.Id.ToString();
 
         Server.DataContext
             .Setup(x => x.UserEntities)
-            .ReturnsDbSet(Fixture.CreateMany<UserEntity>());
+            .ReturnsDbSet(new List<UserEntity> { userEntity });
         
         Server.DataContext
             .Setup(x => x.VacancyEntities)
@@ -139,9 +142,71 @@ public class WhenPostingVacancy: BaseFixture
         response.Headers.Location.Should().NotBeNull();
         response.Headers.Location.ToString().Should().Be($"/api/vacancies/{vacancy.Id}");
         
-        Server.DataContext.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+        Server.DataContext.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
-    
+
+    [Test]
+    public async Task Then_The_Vacancy_Is_Added_New_User_Added()
+    {
+        // arrange
+        var vacancyReference = Fixture.Create<VacancyReference>();
+        var request = Fixture.Create<SFA.DAS.Recruit.Contracts.ApiResponses.PostVacancyRequest>();
+
+        Server.DataContext
+            .Setup(x => x.UserEntities)
+            .ReturnsDbSet(Fixture.Create<List<UserEntity>>());
+
+        Server.DataContext
+            .Setup(x => x.VacancyEntities)
+            .ReturnsDbSet(Fixture.CreateMany<VacancyEntity>(10).ToList());
+
+        Server.DataContext
+            .Setup(x => x.VacancyEntities.AddAsync(It.IsAny<VacancyEntity>(), It.IsAny<CancellationToken>()))
+            .Callback((VacancyEntity entity, CancellationToken _) => { entity.Id = request.Id!.Value; });
+
+        Server.DataContext
+            .Setup(x => x.GetNextVacancyReferenceAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(vacancyReference.Value);
+
+        // act
+        var requestTest = new PostVacanciesApiRequest(request);
+        var response = await Client.PostAsJsonAsync(requestTest.PostUrl, requestTest.Data);
+        var vacancy = await response.Content.ReadAsAsync<SFA.DAS.Recruit.Contracts.ApiResponses.Vacancy>();
+
+        // assert
+        vacancy.Should().BeEquivalentTo(request, opt => opt
+            .Excluding(x => x.SubmittedByUserId)
+            .Excluding(x => x.ReviewRequestedByUserId)
+            .Excluding(x => x.ArchivedByUserId)
+            .Excluding(x => x.Wage!.ApprenticeMinimumWage)
+            .Excluding(x => x.Wage!.Under18NationalMinimumWage)
+            .Excluding(x => x.Wage!.Between18AndUnder21NationalMinimumWage)
+            .Excluding(x => x.Wage!.Between21AndUnder25NationalMinimumWage)
+            .Excluding(x => x.Wage!.Over25NationalMinimumWage)
+            .Excluding(x => x.Wage!.WageText)
+            .Excluding(x => x.ApprovedDate)
+            .Excluding(x => x.LastUpdatedDate)
+            .Excluding(x => x.SubmittedDate)
+            .Excluding(x => x.ReviewRequestedDate)
+            .Excluding(x => x.ClosingDate)
+            .Excluding(x => x.DeletedDate)
+            .Excluding(x => x.LiveDate)
+            .Excluding(x => x.StartDate)
+            .Excluding(x => x.ClosingDate)
+            .Excluding(x => x.ClosedDate)
+            .Excluding(x => x.TransferInfo!.TransferredDate)
+            .Excluding(x => x.Id)
+        );
+        vacancy.Id.Should().Be(request.Id!.Value);
+        vacancy.VacancyReference.Should().Be(vacancyReference.Value);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        response.Headers.Location.Should().NotBeNull();
+        response.Headers.Location.ToString().Should().Be($"/api/vacancies/{vacancy.Id}");
+
+        Server.DataContext.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Exactly(2));
+    }
+
     [Test]
     public async Task Then_The_SubmittedUserId_Is_Looked_Up_IdamsUserId()
     {

--- a/src/Recruit.Api.IntegrationTests/Controllers/VacancyControllerTests/WhenPostingVacancy.cs
+++ b/src/Recruit.Api.IntegrationTests/Controllers/VacancyControllerTests/WhenPostingVacancy.cs
@@ -139,7 +139,7 @@ public class WhenPostingVacancy: BaseFixture
         response.Headers.Location.Should().NotBeNull();
         response.Headers.Location.ToString().Should().Be($"/api/vacancies/{vacancy.Id}");
         
-        Server.DataContext.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        Server.DataContext.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.AtLeastOnce);
     }
     
     [Test]

--- a/src/Recruit.Api/Controllers/VacancyController.cs
+++ b/src/Recruit.Api/Controllers/VacancyController.cs
@@ -539,6 +539,15 @@ public class VacancyController([FromServices] IUserRepository userRepository) : 
                ?? await TryEmail()
                ?? await CreateUser();
 
+        // This lookup should eventually be removed once we've migrated away from Mongo
+        // We do this because currently the submitted user id is not the SQL user id, but could match
+        // the IdamsUserId, DfEUserId or the actual UserId.
+        async Task<Guid?> TrySubmittedId()
+        {
+            if (request.SubmittedByUserId is null) return null;
+            return await userRepository.FindIdByUserIdAsync(request.SubmittedByUserId, ct);
+        }
+
         // If we couldn't find the user by the ID, then we try to find the user based on the contact details
         async Task<Guid?> TryEmail()
         {
@@ -561,15 +570,6 @@ public class VacancyController([FromServices] IUserRepository userRepository) : 
                 ct);
 
             return user.Entity.Id;
-        }
-
-        // This lookup should eventually be removed once we've migrated away from Mongo
-        // We do this because currently the submitted user id is not the SQL user id, but could match
-        // the IdamsUserId, DfEUserId or the actual UserId.
-        async Task<Guid?> TrySubmittedId()
-        {
-            if (request.SubmittedByUserId is null) return null;
-            return await userRepository.FindIdByUserIdAsync(request.SubmittedByUserId, ct);
         }
     }
 }

--- a/src/Recruit.Api/Controllers/VacancyController.cs
+++ b/src/Recruit.Api/Controllers/VacancyController.cs
@@ -20,11 +20,12 @@ using SFA.DAS.Recruit.Api.Models.Responses.Vacancy;
 using SFA.DAS.Recruit.Api.Services;
 using SFA.DAS.Recruit.Api.Validators;
 using SFA.DAS.Recruit.Api.Validators.VacancyEntity;
+using UserType = SFA.DAS.Recruit.Api.Domain.Enums.UserType;
 
 namespace SFA.DAS.Recruit.Api.Controllers;
 
 [ApiController, Route($"{RouteNames.Vacancies}")]
-public class VacancyController : Controller
+public class VacancyController([FromServices] IUserRepository userRepository) : Controller
 {
     [HttpGet, Route("{vacancyId:guid}")]
     [ProducesResponseType(typeof(Vacancy), StatusCodes.Status200OK)]
@@ -313,19 +314,9 @@ public class VacancyController : Controller
             entity.Id = request.Id ?? Guid.NewGuid();
             return TypedResults.Created($"/{RouteNames.Vacancies}/{entity.Id}", entity.ToPostResponse());
         }
-
-        // This lookup should eventually be removed once we've migrated away from Mongo
-        // We do this because currently the submitted user id is not the SQL user id, but could match
-        // the IdamsUserId, DfEUserId or the actual UserId.
-        if (request.SubmittedByUserId is not null)
-        {
-            var userId = await userRepository.FindIdByUserIdAsync(request.SubmittedByUserId, cancellationToken);
-            if (userId is not null)
-            {
-                entity.SubmittedByUserId = userId;
-            }
-        }
         
+        entity.SubmittedByUserId = await ResolveSubmittedByUserIdAsync(request, cancellationToken);
+
         // This lookup should eventually be removed once we've migrated away from Mongo
         // We do this because currently the submitted user id is not the SQL user id, but could match
         // the IdamsUserId, DfEUserId or the actual UserId.
@@ -536,5 +527,49 @@ public class VacancyController : Controller
         var applicationReviewStats = await applicationReviewsProvider.GetVacancyReferencesCountByAccountId(accountId, vacancyReferences, null, cancellationToken);
         var applicationReviewStatsDict = applicationReviewStats.ToDictionary(x => x.VacancyReference);
         return TypedResults.Ok(new DataResponse<Dictionary<long, ApplicationReviewsStats>>(applicationReviewStatsDict));
+    }
+
+    private async Task<Guid> ResolveSubmittedByUserIdAsync(VacancyRequest request, CancellationToken ct)
+    {
+        var userType = request.OwnerType == OwnerType.Employer
+            ? UserType.Employer
+            : UserType.Provider;
+
+        return await TrySubmittedId()
+               ?? await TryEmail()
+               ?? await CreateUser();
+
+        // If we couldn't find the user by the ID, then we try to find the user based on the contact details
+        async Task<Guid?> TryEmail()
+        {
+            if (request.Contact?.Email is null) return null;
+            var user = await userRepository.FindUserByEmailAsync(request.Contact.Email, userType, ct);
+            return user?.Id;
+        }
+
+        // If the user doesn't exist then we want to create a new user based on the contact details provided and link to the vacancy
+        async Task<Guid> CreateUser()
+        {
+            var user = await userRepository.UpsertOneAsync(
+                new UserEntity {
+                    Id = Guid.NewGuid(),
+                    Name = request.Contact?.Name!,
+                    Email = request.Contact?.Email!,
+                    UserType = userType,
+                    CreatedDate = DateTime.UtcNow,
+                },
+                ct);
+
+            return user.Entity.Id;
+        }
+
+        // This lookup should eventually be removed once we've migrated away from Mongo
+        // We do this because currently the submitted user id is not the SQL user id, but could match
+        // the IdamsUserId, DfEUserId or the actual UserId.
+        async Task<Guid?> TrySubmittedId()
+        {
+            if (request.SubmittedByUserId is null) return null;
+            return await userRepository.FindIdByUserIdAsync(request.SubmittedByUserId, ct);
+        }
     }
 }


### PR DESCRIPTION
refactor(controller): encapsulate user resolution logic

Refactored `VacancyController` to use dependency injection for `IUserRepository` and encapsulated `SubmittedByUserId` resolution logic in a new private method `ResolveSubmittedByUserIdAsync`.

The new method modularizes user resolution by attempting to resolve the user ID via `SubmittedByUserId`, email lookup, or creating a new user. Introduced `UserType` enum to differentiate between Employer and Provider users. Removed redundant MongoDB lookup logic from the controller, improving readability and maintainability.