### PR TITLE
FAI-3462 ArchiveType DB field auto-populating to "Auto" for vacancies from API

### DIFF
--- a/src/Recruit.Api/Controllers/VacancyController.cs
+++ b/src/Recruit.Api/Controllers/VacancyController.cs
@@ -346,7 +346,8 @@ public class VacancyController : Controller
         var vacancyReference = await repository.GetNextVacancyReferenceAsync(cancellationToken);
         entity.VacancyReference = vacancyReference.Value;
         entity.CreatedDate = DateTime.UtcNow;
-        
+        entity.ArchiveType = null; // Reset archive type when creating a new vacancy. Interim solution until we have a patch the contracts.
+
         var result = await repository.UpsertOneAsync(entity, cancellationToken);
         await eventsService.HandleVacancyStatusChange(result);
         


### PR DESCRIPTION
Reset ArchiveType to null on vacancy creation

Explicitly set entity.ArchiveType to null when creating a new vacancy to ensure it is reset. This is an interim workaround until a contract patch is implemented. No other logic was modified.