### PR TITLE
FAI-3454 FAI-3451 Hotfix Make BeforeEdit/AfterEdit nullable in ManualQaEditFieldIndicator

### DIFF
--- a/src/Recruit.Api.Domain/Models/ManualQaEditFieldIndicator.cs
+++ b/src/Recruit.Api.Domain/Models/ManualQaEditFieldIndicator.cs
@@ -3,6 +3,6 @@
 public class ManualQaEditFieldIndicator
 {
     public string FieldIdentifier { get; set; }
-    public string BeforeEdit { get; set; }
-    public string AfterEdit { get; set; }
+    public string? BeforeEdit { get; set; } = null;
+    public string? AfterEdit { get; set; } = null;
 }


### PR DESCRIPTION
Make BeforeEdit/AfterEdit nullable in ManualQaEditFieldIndicator

Changed BeforeEdit and AfterEdit properties from non-nullable string to nullable string (string?) to allow null values in ManualQaEditFieldIndicator.