### PR TITLE
FAI-3461 - Change so that VacancyReview can not be changed if bypassed

### DIFF
--- a/src/Recruit.Api.Data/Repositories/VacancyReviewRepository.cs
+++ b/src/Recruit.Api.Data/Repositories/VacancyReviewRepository.cs
@@ -45,6 +45,13 @@ public class VacancyReviewRepository(IRecruitDataContext dataContext): IVacancyR
             return UpsertResult.Create(entity, true, true);
         }
         
+        // To cover scenario where the LLM process the vacancy review twice and gives
+        // a different result
+        if(existingEntity.ManualOutcome == nameof(ManualQaOutcome.Bypassed))
+        {
+            return UpsertResult.Create(entity, false, false);
+        }
+        
         var oldStatus = existingEntity.Status;
         existingEntity.SubmittedByUserEmail = entity.SubmittedByUserEmail;
 

--- a/src/Recruit.Api.IntegrationTests/Controllers/VacancyReviewControllerTests/WhenPuttingVacancyReview.cs
+++ b/src/Recruit.Api.IntegrationTests/Controllers/VacancyReviewControllerTests/WhenPuttingVacancyReview.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using Microsoft.AspNetCore.Mvc;
 using SFA.DAS.Recruit.Api.Domain.Entities;
+using SFA.DAS.Recruit.Api.Domain.Enums;
 using SFA.DAS.Recruit.Api.Models;
 using SFA.DAS.Recruit.Api.Models.Mappers;
 using SFA.DAS.Recruit.Api.Models.Requests.VacancyReview;
@@ -84,6 +85,29 @@ public class WhenPuttingVacancyReview: BaseFixture
         updatedItem.SubmittedByUserEmail = targetItem.SubmittedByUserEmail;
         Server.DataContext.Verify(x => x.SetValues(targetItem, ItIs.EquivalentTo(updatedItem)), Times.Once());
         Server.DataContext.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+    
+    [Test]
+    public async Task Then_The_VacancyReview_Is_Not_Replaced_If_Already_Bypassed()
+    {
+        // arrange
+        var items = Fixture.CreateMany<VacancyReviewEntity>(1).ToList();
+        var targetItem = items[0];
+        targetItem.ManualOutcome = nameof(ManualQaOutcome.Bypassed);
+        Server.DataContext
+            .Setup(x => x.VacancyReviewEntities)
+            .ReturnsDbSet(items);
+
+        var request = Fixture.Create<PutVacancyReviewRequest>();
+        
+        // act
+        var response = await Client.PutAsJsonAsync(new PutVacancyreviewsByIdApiRequest { Id = targetItem.Id }.PutUrl, request);
+        
+        // assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        
+        Server.DataContext.Verify(x => x.SetValues(It.IsAny<VacancyReviewEntity>(), It.IsAny<VacancyReviewEntity>()), Times.Never());
+        Server.DataContext.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Test]

--- a/src/Recruit.Api/Models/Requests/VacancyReview/PutVacancyReviewRequest.cs
+++ b/src/Recruit.Api/Models/Requests/VacancyReview/PutVacancyReviewRequest.cs
@@ -18,7 +18,7 @@ public class PutVacancyReviewRequest
     public string? ReviewedByUserEmail { get; init; }
     public string? SubmittedByUserEmail { get; set; }
     public DateTime? ClosedDate { get; init; }
-    public string? ManualOutcome { get; init; }
+    public string? ManualOutcome { get; set; }
     public string? ManualQaComment { get; init; }
     public List<string>? ManualQaFieldIndicators { get; init; } = [];
     public List<ManualQaEditFieldIndicator>? ManualQaEditFieldIndicators { get; init; }


### PR DESCRIPTION
If the vacancy review has already been bypassed and closed we need to make sure that we dont update it again if the vacancy review is reprocessed by accident due to the LLM timing out on vacancy ai api, or if the message is processed twice giving different results